### PR TITLE
Demo asset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .*.swp
+.project
+.DS_Store

--- a/Kubernetes.yml
+++ b/Kubernetes.yml
@@ -20,9 +20,7 @@ RightScripts:
   - RL10_Linux_Upgrade.sh
   - RL10_Linux_Enable_Docker_Support_Beta.sh
 MultiCloudImages:
-- Name: Ubuntu_16.04_x64
-  Revision: 5
-  Publisher: RightScale
+- Name: PFT Ubuntu 16.04
 Alerts:
 - Name: rs instance terminated
   Description: Raise an alert if the instance has been terminated abnormally, i.e.

--- a/Kubernetes_Setup.sh
+++ b/Kubernetes_Setup.sh
@@ -18,6 +18,13 @@ IFS=$'\n\t'
 #     Required: true
 #     Advanced: true
 #     Default: cred:RS_REFRESH_TOKEN
+#   RS_SERVER:
+#     Category: Cluster
+#     Description: RS API Endpoint
+#     Input Type: single
+#     Required: true
+#     Advanced: true
+#     Default: env:RS_SERVER
 #   RS_CLUSTER_ROLE:
 #     Category: Cluster
 #     Input Type: single

--- a/Kubernetes_Setup.sh
+++ b/Kubernetes_Setup.sh
@@ -50,6 +50,7 @@ IFS=$'\n\t'
 # - rs_kubernetes.sh
 # - kube_flannel.yml
 # - kube_dashboard.yml
+# - kube_dashboard_admin.yml
 # - kube_influxdb.yml
 # ...
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Launches a Kubernetes cluster using IaaS components (i.e. servers).
 This is as opposed to using a Container as a Service or Kubernetes as a Service offering to stand up the cluster.
 
 # Prerequisites
-- AWS or Google cloud connected to the account.
+- AWS and/or AzureRM and/or Google connected to the account.
 
 # Set up
 - Create "PFT Ubuntu 16.04" MCI in the account if necessary.
@@ -14,5 +14,10 @@ This is as opposed to using a Container as a Service or Kubernetes as a Service 
   - https://github.com/rs-services/rs-premium_free_trial/blob/master/Account_Management/mci_management.pkg.rb
 - Upload the "pft/mci/linux_mappings" package file
   - https://github.com/rs-services/rs-premium_free_trial/blob/master/Account_Management/mci_management_linux_mappings.pkg.rb
-
 - Upload and publish the kubernetes.cat.rb file 
+
+# Usage
+- Launch the CAT
+  - You must provide your IP address to be able to access the Kubernetes dashboard.
+- Once launched click the link to the dashboard.
+  - Click "Skip" on the login screen.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# kubernetes
+# Kubernetes IaaS Cluster
+Launches a Kubernetes cluster using IaaS components (i.e. servers).
+This is as opposed to using a Container as a Service or Kubernetes as a Service offering to stand up the cluster.
+
+# Prerequisites
+- AWS or Google cloud connected to the account.
+
+# Set up
+- Create "PFT Ubuntu 16.04" MCI in the account if necessary.
+  - This CAT can be used to set up the MCI: https://github.com/rs-services/rs-premium_free_trial/blob/master/Account_Management/mci_management_base_linux.cat.rb
+- Create credential named, RS_REFRESH_TOKEN containing a valid refresh token.
+- Run right_st and pass it the Kubernetes.yml file
+- Upload the "pft/mci" package file.
+  - https://github.com/rs-services/rs-premium_free_trial/blob/master/Account_Management/mci_management.pkg.rb
+- Upload the "pft/mci/linux_mappings" package file
+  - https://github.com/rs-services/rs-premium_free_trial/blob/master/Account_Management/mci_management_linux_mappings.pkg.rb
+
+- Upload and publish the kubernetes.cat.rb file 

--- a/attachments/kube_dashboard.yml
+++ b/attachments/kube_dashboard.yml
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All Rights Reserved.
+# Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,68 +12,151 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Configuration to deploy release version of the Dashboard UI.
+# Configuration to deploy release version of the Dashboard UI compatible with
+# Kubernetes 1.7.
 #
 # Example usage: kubectl create -f <this_file>
+
+# ------------------- Dashboard Secret ------------------- #
+
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-certs
+  namespace: kube-system
+type: Opaque
+
+---
+# ------------------- Dashboard Service Account ------------------- #
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kube-system
+
+---
+# ------------------- Dashboard Role & Role Binding ------------------- #
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kubernetes-dashboard-minimal
+  namespace: kube-system
+rules:
+  # Allow Dashboard to create and watch for changes of 'kubernetes-dashboard-key-holder' secret.
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create", "watch"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  # Allow Dashboard to get, update and delete 'kubernetes-dashboard-key-holder' secret.
+  resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-certs"]
+  verbs: ["get", "update", "delete"]
+  # Allow Dashboard to get metrics from heapster.
+- apiGroups: [""]
+  resources: ["services"]
+  resourceNames: ["heapster"]
+  verbs: ["proxy"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: kubernetes-dashboard-minimal
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubernetes-dashboard-minimal
+subjects:
+- kind: ServiceAccount
+  name: kubernetes-dashboard
+  namespace: kube-system
+
+---
+# ------------------- Dashboard Deployment ------------------- #
 
 kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
   labels:
-    app: kubernetes-dashboard
+    k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard
   namespace: kube-system
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: kubernetes-dashboard
+      k8s-app: kubernetes-dashboard
   template:
     metadata:
       labels:
-        app: kubernetes-dashboard
-      # Comment the following annotation if Dashboard must not be deployed on master
-      annotations:
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [
-            {
-              "key": "dedicated",
-              "operator": "Equal",
-              "value": "master",
-              "effect": "NoSchedule"
-            }
-          ]
+        k8s-app: kubernetes-dashboard
     spec:
+      initContainers:
+      - name: kubernetes-dashboard-init
+        image: gcr.io/google_containers/kubernetes-dashboard-init-amd64:v1.0.1
+        volumeMounts:
+        - name: kubernetes-dashboard-certs
+          mountPath: /certs
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.1
-        imagePullPolicy: Always
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.7.1
         ports:
-        - containerPort: 9090
+        - containerPort: 8443
           protocol: TCP
         args:
+          - --tls-key-file=/certs/dashboard.key
+          - --tls-cert-file=/certs/dashboard.crt
           # Uncomment the following line to manually specify Kubernetes API server Host
           # If not specified, Dashboard will attempt to auto discover the API server and connect
           # to it. Uncomment only if the default does not work.
           # - --apiserver-host=http://my-address:port
+        volumeMounts:
+        - name: kubernetes-dashboard-certs
+          mountPath: /certs
+          readOnly: true
+          # Create on-disk volume to store exec logs
+        - mountPath: /tmp
+          name: tmp-volume
         livenessProbe:
           httpGet:
+            scheme: HTTPS
             path: /
-            port: 9090
+            port: 8443
           initialDelaySeconds: 30
           timeoutSeconds: 30
+      volumes:
+      - name: kubernetes-dashboard-certs
+        secret:
+          secretName: kubernetes-dashboard-certs
+      - name: tmp-volume
+        emptyDir: {}
+      serviceAccountName: kubernetes-dashboard
+      # Comment the following tolerations if Dashboard must not be deployed on master
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+
 ---
+# ------------------- Dashboard Service ------------------- #
+
 kind: Service
 apiVersion: v1
 metadata:
   labels:
-    app: kubernetes-dashboard
+    k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard
   namespace: kube-system
 spec:
-  type: NodePort
   ports:
-  - port: 80
-    targetPort: 9090
+    - port: 443
+      targetPort: 8443
   selector:
-    app: kubernetes-dashboard
+    k8s-app: kubernetes-dashboard

--- a/attachments/kube_dashboard_admin.yml
+++ b/attachments/kube_dashboard_admin.yml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-dashboard
+  labels:
+    k8s-app: kubernetes-dashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: kubernetes-dashboard
+  namespace: kube-system

--- a/attachments/kube_flannel.yml
+++ b/attachments/kube_flannel.yml
@@ -1,13 +1,53 @@
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: flannel
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: flannel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flannel
+subjects:
+- kind: ServiceAccount
+  name: flannel
+  namespace: kube-system
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: flannel
+  namespace: kube-system
 ---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: kube-flannel-cfg
+  namespace: kube-system
   labels:
     tier: node
     app: flannel
@@ -32,6 +72,7 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: kube-flannel-ds
+  namespace: kube-system
   labels:
     tier: node
     app: flannel
@@ -45,10 +86,28 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
       serviceAccountName: flannel
+      initContainers:
+      - name: install-cni
+        image: quay.io/coreos/flannel:v0.9.0-amd64
+        command:
+        - cp
+        args:
+        - -f
+        - /etc/kube-flannel/cni-conf.json
+        - /etc/cni/net.d/10-flannel.conf
+        volumeMounts:
+        - name: cni
+          mountPath: /etc/cni/net.d
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.7.0-amd64
+        image: quay.io/coreos/flannel:v0.9.0-amd64
         command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
         securityContext:
           privileged: true
@@ -64,14 +123,6 @@ spec:
         volumeMounts:
         - name: run
           mountPath: /run
-        - name: flannel-cfg
-          mountPath: /etc/kube-flannel/
-      - name: install-cni
-        image: quay.io/coreos/flannel:v0.7.0-amd64
-        command: [ "/bin/sh", "-c", "set -e -x; cp -f /etc/kube-flannel/cni-conf.json /etc/cni/net.d/10-flannel.conf; while true; do sleep 3600; done" ]
-        volumeMounts:
-        - name: cni
-          mountPath: /etc/cni/net.d
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
       volumes:

--- a/attachments/rs_kubernetes.sh
+++ b/attachments/rs_kubernetes.sh
@@ -13,8 +13,8 @@ EOF
   sudo apt-get install -y docker.io
   sudo apt-get install -y kubelet kubeadm kubectl kubernetes-cni
 
-  # Initialize the master
-  token=$(sudo kubeadm init --pod-network-cidr 10.244.0.0/16 | tail -n 1)
+  # Initialize the master and grab the join command to be used by the cluster nodes
+  token=$(sudo kubeadm init --pod-network-cidr 10.244.0.0/16 | grep -i "kubeadm join")
 
   # Save the token as a RightScale credential
   rsc --refreshToken="$RS_REFRESH_TOKEN" --host=us-4.rightscale.com cm15 create credentials \

--- a/attachments/rs_kubernetes.sh
+++ b/attachments/rs_kubernetes.sh
@@ -22,12 +22,24 @@ EOF
   rsc --refreshToken="$RS_REFRESH_TOKEN" --host="$RS_API_ENDPOINT" cm15 create credentials \
     credential[name]="KUBE_${RS_CLUSTER_NAME}_CLUSTER_TOKEN" \
     credential[value]="$token"
+    
+  # When you run the kubeadm init command along with the join command that is grabbed above,
+  # it provides these instructions for steps that need to be taken before subsequent commands will work:
+  mkdir -p $HOME/.kube
+  sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+  sudo chown $(id -u):$(id -g) $HOME/.kube/config
 
   # Initialize the overlay network
+  echo ">>> flannel set up"
   sudo kubectl apply -f "$RS_ATTACH_DIR/kube_flannel.yml"
+  
+  echo ">>> dashboard set up"
   sudo kubectl apply -f "$RS_ATTACH_DIR/kube_dashboard.yml"
+  
+  echo ">>> influxdb set up"
   sudo kubectl apply -f "$RS_ATTACH_DIR/kube_influxdb.yml"
 
+  echo ">>> get dashboard port"
   dashboard_port=$(sudo kubectl get svc -n kube-system | grep '^kubernetes-dashboard ' | awk '{print $4}' | cut -f1 -d/ | cut -f2 -d:)
 
   rs_cluster_tag "rs_cluster:dashboard_port=$dashboard_port"
@@ -46,5 +58,6 @@ EOF
   sudo apt-get install -y kubelet kubeadm kubectl kubernetes-cni
 
   # Join cluster
+  echo ">>> Join cluster"
   eval "sudo $KUBE_CLUSTER_JOIN_CMD"
 }

--- a/attachments/rs_kubernetes.sh
+++ b/attachments/rs_kubernetes.sh
@@ -15,9 +15,11 @@ EOF
 
   # Initialize the master and grab the join command to be used by the cluster nodes
   token=$(sudo kubeadm init --pod-network-cidr 10.244.0.0/16 | grep -i "kubeadm join")
+  
+  RS_API_ENDPOINT=$(echo $RS_SERVER | cut -d '\' -f3)
 
   # Save the token as a RightScale credential
-  rsc --refreshToken="$RS_REFRESH_TOKEN" --host=us-4.rightscale.com cm15 create credentials \
+  rsc --refreshToken="$RS_REFRESH_TOKEN" --host="$RS_API_ENDPOINT" cm15 create credentials \
     credential[name]="KUBE_${RS_CLUSTER_NAME}_CLUSTER_TOKEN" \
     credential[value]="$token"
 

--- a/kubernetes.cat.rb
+++ b/kubernetes.cat.rb
@@ -1,6 +1,6 @@
 name 'Kubernetes Cluster'
 rs_ca_ver 20161221
-short_description "![logo](https://dl.dropboxusercontent.com/u/2202802/nav_logo.png)
+short_description "![logo](https://s3.amazonaws.com/rs-pft/cat-logos/kubernetes.png)
 
 Creates a Kubernetes cluster"
 

--- a/kubernetes.cat.rb
+++ b/kubernetes.cat.rb
@@ -138,7 +138,6 @@ parameter "admin_ip" do
   description "Allowed source IP for cluster administration. This IP address will have access to the cluster dashboard."
   allowed_pattern "^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$"
   constraint_description "Please enter a single IP address. Additional IPs can be added after launch."
-  default "23.28.197.95"
 end
 
 condition "needsSecurityGroup" do


### PR DESCRIPTION
This is an update of the kubernetes IaaS cluster CAT and assets that is a bit more portable and demo-friendly. 
It supports AWS, ARM and Google.
It changes some of the fundamentals around networking by creating its own VPC and subnets and avoids the group-id based security groups.